### PR TITLE
Fix buffer handling and memory cleanup

### DIFF
--- a/src/AsyncPrinter_Impl.h
+++ b/src/AsyncPrinter_Impl.h
@@ -291,11 +291,12 @@ size_t AsyncPrinter::_sendBuffer()
   {
     // Connection should be aborted instead
     ATCP_LOGERROR("AsyncPrinter:_sendBuffer: Error NULL out");
+    return 0;
   }
 
   _tx_buffer->read(out, available);
   size_t sent = _client->write(out, available);
-  delete out;
+  delete[] out;
 
   return sent;
 }

--- a/src/Teensy41_AsyncTCP_Buffer_Impl.h
+++ b/src/Teensy41_AsyncTCP_Buffer_Impl.h
@@ -517,7 +517,7 @@ void AsyncTCPbuffer::_sendBuffer()
       ATCP_LOGDEBUG("delete cbuf");
     }
 
-    delete out;
+    delete[] out;
   }
 }
 
@@ -635,11 +635,13 @@ size_t AsyncTCPbuffer::_handleRxBuffer(uint8_t *buf, size_t len)
       {
         //TODO: What action should this be ?
         ATCP_LOGERROR("AsyncTCPbuffer::_handleRxBuffer: Error NULL buffer");
+        return 0;
       }
 
       _RXbuffer->peek((char *) b, BufferAvailable);
       r = _cbRX(b, BufferAvailable);
       _RXbuffer->remove(r);
+      delete[] b;
     }
 
     if (r == BufferAvailable && buf && (len > 0))


### PR DESCRIPTION
## Summary
- avoid null pointer dereference in `AsyncPrinter::_sendBuffer`
- use `delete[]` for buffers allocated with `new[]`
- handle allocation failure in `_handleRxBuffer` and release temp buffer

## Testing
- `bash utils/restyle.sh` *(fails: `astyle` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686613441a04832ea946839903e08aac