### PR TITLE
Use copy flag to prevent TX buffer corruption

### DIFF
--- a/src/AsyncPrinter_Impl.h
+++ b/src/AsyncPrinter_Impl.h
@@ -304,7 +304,7 @@ size_t AsyncPrinter::_sendBuffer()
     }
 
     _tx_buffer->peek(out, available);
-    size_t sent = _client->write(out, available);
+    size_t sent = _client->write((const char*) out, available, ASYNC_WRITE_FLAG_COPY);
     _tx_buffer->remove(sent);
     delete[] out;
 

--- a/src/SyncClient_Impl.h
+++ b/src/SyncClient_Impl.h
@@ -410,7 +410,7 @@ size_t SyncClient::_sendBuffer()
       break;
 
     _tx_buffer->peek(out, available);
-    size_t sent = _client->write(out, available);
+    size_t sent = _client->write((const char*) out, available, ASYNC_WRITE_FLAG_COPY);
     _tx_buffer->remove(sent);
     delete[] out;
 


### PR DESCRIPTION
## Summary
- ensure writes copy data before freeing buffers to avoid TX corruption

## Testing
- `platformio run` *(fails: command not found)*
- `pip install platformio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68ba6afb10a0832e843664aa944fa431